### PR TITLE
Add reading-time UI

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -1,0 +1,17 @@
+export {}
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({
+    id: "get-reading-time",
+    title: "Get reading time",
+    contexts: ["selection"]
+  })
+})
+
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+  if (info.menuItemId === "get-reading-time" && info.selectionText) {
+    chrome.storage.local.set({ selectedText: info.selectionText }, () => {
+      chrome.action.openPopup()
+    })
+  }
+})

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
   "manifest": {
     "host_permissions": [
       "https://*/*"
+    ],
+    "permissions": [
+      "contextMenus",
+      "storage"
     ]
   }
 }

--- a/popup.tsx
+++ b/popup.tsx
@@ -1,24 +1,57 @@
 import { useState } from "react"
 
 function IndexPopup() {
-  const [data, setData] = useState("")
+  const [text, setText] = useState("")
+  const [wpm, setWpm] = useState(200)
+
+  const wordCount = text.trim() === "" ? 0 : text.trim().split(/\s+/).length
+  const readingTime = wpm > 0 ? (wordCount / wpm).toFixed(2) : "0"
 
   return (
     <div
       style={{
-        padding: 16
+        padding: 16,
+        fontFamily: "sans-serif",
+        width: 300
       }}>
-      <h2>
-        Welcome to your{" "}
-        <a href="https://www.plasmo.com" target="_blank">
-          Plasmo
-        </a>{" "}
-        Extension!
-      </h2>
-      <input onChange={(e) => setData(e.target.value)} value={data} />
-      <a href="https://docs.plasmo.com" target="_blank">
-        View Docs
-      </a>
+      <h2>Word Counter</h2>
+      <textarea
+        style={{
+          width: "100%",
+          height: 120,
+          resize: "vertical",
+          padding: 8,
+          borderRadius: 4
+        }}
+        placeholder="Type or paste text here..."
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <label
+        style={{
+          display: "block",
+          marginTop: 8
+        }}>
+        Words per minute:
+        <input
+          type="number"
+          min={1}
+          value={wpm}
+          onChange={(e) => setWpm(Number(e.target.value))}
+          style={{
+            width: "100%",
+            marginTop: 4,
+            padding: 4,
+            borderRadius: 4
+          }}
+        />
+      </label>
+      <div style={{ marginTop: 8 }}>
+        <strong>Word count:</strong> {wordCount}
+      </div>
+      <div>
+        <strong>Reading time:</strong> {readingTime} min
+      </div>
     </div>
   )
 }

--- a/popup.tsx
+++ b/popup.tsx
@@ -1,11 +1,28 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 function IndexPopup() {
   const [text, setText] = useState("")
   const [wpm, setWpm] = useState(200)
 
+  useEffect(() => {
+    chrome.storage.local.get(["selectedText", "wpm"], (res) => {
+      if (res.selectedText) {
+        setText(res.selectedText)
+      }
+      if (res.wpm) {
+        setWpm(res.wpm)
+      }
+    })
+  }, [])
+
+  useEffect(() => {
+    chrome.storage.local.set({ wpm })
+  }, [wpm])
+
   const wordCount = text.trim() === "" ? 0 : text.trim().split(/\s+/).length
-  const readingTime = wpm > 0 ? (wordCount / wpm).toFixed(2) : "0"
+  const totalSeconds = wpm > 0 ? Math.ceil((wordCount / wpm) * 60) : 0
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
 
   return (
     <div
@@ -14,18 +31,18 @@ function IndexPopup() {
         fontFamily: "sans-serif",
         width: 300
       }}>
-      <h2>Word Counter</h2>
+      <h2>Reading Time</h2>
       <textarea
         style={{
           width: "100%",
-          height: 120,
+          height: 100,
           resize: "vertical",
           padding: 8,
           borderRadius: 4
         }}
-        placeholder="Type or paste text here..."
+        placeholder="Select text on the page first"
         value={text}
-        onChange={(e) => setText(e.target.value)}
+        readOnly
       />
       <label
         style={{
@@ -50,7 +67,7 @@ function IndexPopup() {
         <strong>Word count:</strong> {wordCount}
       </div>
       <div>
-        <strong>Reading time:</strong> {readingTime} min
+        <strong>Reading time:</strong> {minutes} min {seconds} sec
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- update popup to capture words per minute input
- show word count and estimated reading time

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685f204862808329bc34f0faa79561b2