### PR TITLE
Compute reading time from page text

### DIFF
--- a/content.ts
+++ b/content.ts
@@ -1,0 +1,37 @@
+export {}
+
+function getVisibleText(): string {
+  const clone = document.body.cloneNode(true) as HTMLElement
+
+  // Remove elements we do not want to count words from
+  clone.querySelectorAll('script,style,nav,header,footer,aside').forEach((el) =>
+    el.remove()
+  )
+
+  // Remove hidden elements
+  clone.querySelectorAll('*').forEach((el) => {
+    const element = el as HTMLElement
+    const style = window.getComputedStyle(element)
+    if (style.display === 'none' || style.visibility === 'hidden') {
+      element.remove()
+    }
+  })
+
+  return clone.innerText
+}
+
+function countWords(text: string): number {
+  const cleaned = text.replace(/\s+/g, ' ').trim()
+  if (cleaned === '') {
+    return 0
+  }
+  return cleaned.split(' ').filter(Boolean).length
+}
+
+chrome.runtime.onMessage.addListener((msg, _, sendResponse) => {
+  if (msg.type === 'COUNT_WORDS') {
+    const text = getVisibleText()
+    const count = countWords(text)
+    sendResponse({ count })
+  }
+})

--- a/content.ts
+++ b/content.ts
@@ -33,5 +33,8 @@ chrome.runtime.onMessage.addListener((msg, _, sendResponse) => {
     const text = getVisibleText()
     const count = countWords(text)
     sendResponse({ count })
+  } else if (msg.type === 'GET_SELECTED_TEXT') {
+    const text = window.getSelection()?.toString() ?? ''
+    sendResponse({ text })
   }
 })

--- a/popup.tsx
+++ b/popup.tsx
@@ -1,16 +1,24 @@
 import { useEffect, useState } from "react"
 
 function IndexPopup() {
-  const [text, setText] = useState("")
+  const [wordCount, setWordCount] = useState(0)
   const [wpm, setWpm] = useState(200)
 
   useEffect(() => {
-    chrome.storage.local.get(["selectedText", "wpm"], (res) => {
-      if (res.selectedText) {
-        setText(res.selectedText)
-      }
+    chrome.storage.local.get(["wpm"], (res) => {
       if (res.wpm) {
         setWpm(res.wpm)
+      }
+    })
+
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      const tabId = tabs[0]?.id
+      if (tabId !== undefined) {
+        chrome.tabs.sendMessage(tabId, { type: "COUNT_WORDS" }, (res) => {
+          if (res && typeof res.count === "number") {
+            setWordCount(res.count)
+          }
+        })
       }
     })
   }, [])
@@ -19,7 +27,6 @@ function IndexPopup() {
     chrome.storage.local.set({ wpm })
   }, [wpm])
 
-  const wordCount = text.trim() === "" ? 0 : text.trim().split(/\s+/).length
   const totalSeconds = wpm > 0 ? Math.ceil((wordCount / wpm) * 60) : 0
   const minutes = Math.floor(totalSeconds / 60)
   const seconds = totalSeconds % 60
@@ -32,18 +39,6 @@ function IndexPopup() {
         width: 300
       }}>
       <h2>Reading Time</h2>
-      <textarea
-        style={{
-          width: "100%",
-          height: 100,
-          resize: "vertical",
-          padding: 8,
-          borderRadius: 4
-        }}
-        placeholder="Select text on the page first"
-        value={text}
-        readOnly
-      />
       <label
         style={{
           display: "block",


### PR DESCRIPTION
## Summary
- add content script to collect visible page text and count words
- simplify popup to remove selected text field and use word count from the page

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685f2786147883299c3180a4a318d0a9